### PR TITLE
change letsencrypt to certbot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,12 +13,12 @@ RUN  sh -c '[ -d /opt/go    ] || mkdir -p /opt/go' \
 RUN  sh -c 'echo http://dl-cdn.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositories' \
   && apk update \
   && apk upgrade \
-  && apk add -U h2o letsencrypt go git bzr mercurial py-pip curl bash \
+  && apk add -U h2o certbot go git bzr mercurial py-pip curl bash musl-dev \
   && sh -c 'curl -L "$DOCKERGEN_BINARY_URL" | tar -C /usr/bin -xz && chmod +x /usr/bin/docker-gen' \
   && sh -c 'go get -u -v $FOREGO_GO_URL && mv /opt/go/bin/forego /usr/bin/ && chmod +x /usr/bin/forego' \
   && sh -c 'pip install devcron' \
   && rm -rf $GOPATH \
-  && apk del -U go git bzr mercurial curl \
+  && apk del -U go git bzr mercurial curl musl-dev \
   && rm -rf /var/cache/apk/*
 
 ENV DOCKER_HOST unix:///tmp/docker.sock

--- a/templates/le.sh
+++ b/templates/le.sh
@@ -16,7 +16,7 @@ fi
 {{ if (ne $host "") }}
 [ -d "/opt/data/{{ $host }}" ] || mkdir -p "/opt/data/{{ $host }}"
 
-letsencrypt certonly \
+certbot certonly \
   --webroot \
   --webroot-path "/opt/data/{{ $host }}" \
   --email $EMAIL \


### PR DESCRIPTION
Hello.

The name of the command "letsencrypt" was changed to "certbot".

Also, it corresponds to the fact that the Go cross-compilation library is no longer included in the new version.

The operation was lightly verified.

Best Regard.